### PR TITLE
Add option to install build dependencies using conda rather than manual

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "pybind11"]
-	path = external/pybind11
-	url = https://github.com/pybind/pybind11
 [submodule "external/googletest"]
 	path = external/googletest
 	url = https://github.com/google/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "pybind11"]
+ 	path = external/pybind11
+ 	url = https://github.com/pybind/pybind11
 [submodule "external/googletest"]
 	path = external/googletest
 	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,3 +243,11 @@ if (BUILD_DOCS)
         message("Doxygen need to be installed to generate the doxygen documentation")
     endif (DOXYGEN_FOUND)
 endif ()
+
+if (BININSTALL)
+        install(FILES build/CyRSoXS DESTINATION bin)
+endif ()
+
+if (LIBINSTALL)
+        install(FILES build-pybind/CyRSoXS.so DESTINATION lib)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0048 NEW)
-project(Cy-RSoXS VERSION 1.1.4.0 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
+project(Cy-RSoXS VERSION 1.1.4.1 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
 
 
 option(DOUBLE_PRECISION "Use 64 bit indices for floating point" OFF)
@@ -80,16 +80,17 @@ endif ()
 # BEGIN code that was contributed by employees of the National Institute of Standards and Technology (NIST), 
 # an agency of the Federal Government and is being made available as a public service.
 # Pursuant to title 17 United States Code Section 105, works of NIST employees are not subject to copyright protection in the United States
+
 if (PYBIND)
     # find_package(PythonInterp 3.6 REQUIRED)
     # find_package(PythonLibs 3.6 REQUIRED)
     find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
-    set(PYBIND_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/external/pybind11)
-    add_subdirectory(${PYBIND_LOCATION})
+    #set(PYBIND_LOCATION "${CONDA_PREFIX}/include/pybind11")
+    #add_subdirectory(${PYBIND_LOCATION})
     include_directories(
             ${PYTHON_INCLUDE_DIRS}
-            external/pybind11/include
+            #${CONDA_PREFIX}/include/pybind11
     )
 else ()
     find_package(Config++)
@@ -97,6 +98,8 @@ else ()
         message(FATAL_ERROR "Libconfig++ could not be located.")
     endif ()
 endif ()
+
+
 # END code that was contributed by employees of NIST
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0048 NEW)
-project(Cy-RSoXS VERSION 1.1.4.1 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
+project(Cy-RSoXS VERSION 1.1.5 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
 
 
 option(DOUBLE_PRECISION "Use 64 bit indices for floating point" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(BIAXIAL "Biaxial Computation" OFF)
 option(BUILD_DOCS "Build Documentation" OFF)
 option(PYBIND "Pybind support for Cy-RSOXS " OFF)
 option(USE_64_BIT_INDICES, "Use 64 Bit Indices" OFF)
+option(USE_SUBMODULE_PYBIND,"Use submodule Pybind instead of system" ON)
 option(ENABLE_TEST, "Enable test" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
@@ -86,11 +87,13 @@ if (PYBIND)
     # find_package(PythonLibs 3.6 REQUIRED)
     find_package(Python COMPONENTS Interpreter Development REQUIRED)
 
-    #set(PYBIND_LOCATION "${CONDA_PREFIX}/include/pybind11")
-    #add_subdirectory(${PYBIND_LOCATION})
+    if (USE_SUBMODULE_PYBIND)
+        set(PYBIND_LOCATION "include/pybind11")
+        add_subdirectory(${PYBIND_LOCATION})
+        include_directories(include/pybind11)
+    endif ()
     include_directories(
             ${PYTHON_INCLUDE_DIRS}
-            #${CONDA_PREFIX}/include/pybind11
     )
 else ()
     find_package(Config++)
@@ -244,10 +247,8 @@ if (BUILD_DOCS)
     endif (DOXYGEN_FOUND)
 endif ()
 
-if (BININSTALL)
-        install(FILES build/CyRSoXS DESTINATION bin)
-endif ()
-
-if (LIBINSTALL)
+if (PYBIND)
         install(FILES build-pybind/CyRSoXS.so DESTINATION lib)
+else ()
+        install(FILES build/CyRSoXS DESTINATION bin)
 endif ()

--- a/environment-build.yml
+++ b/environment-build.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gcc
+  - cxx-compiler
   - pybind11
   - cmake
   - make

--- a/environment-build.yml
+++ b/environment-build.yml
@@ -1,0 +1,14 @@
+name: cyrsoxs-build
+
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - gcc
+  - pybind11
+  - cmake
+  - make
+  - hdf5
+  - libconfig
+  - cudatoolkit
+  - openmp


### PR DESCRIPTION
I believe that this remains compatible with the old build toolchain, but also you can do

`conda create -f environment-build.yml`

and skip directly to 

`mkdir build && cd build`
`cmake .. -DCMAKE_BUILD_TYPE=Release`
`sudo make install `

and/or

`mkdir build-pybind && cd build-pybind`
  `cmake .. -DCMAKE_BUILD_TYPE=Release -DPYBIND=Yes -DUSE_SUBMOUDLE_PYBIND=No`
 ` sudo make install `

This also lays the groundwork for conda-forge building.