### PR TITLE
Changes, mainly to CMakeLists, to enable Conda packaging of cyrsoxs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0048 NEW)
-project(Cy-RSoXS VERSION 1.1.5.0 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
+project(Cy-RSoXS VERSION 9.1.5.0 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
 
 
 option(DOUBLE_PRECISION "Use 64 bit indices for floating point" OFF)
@@ -270,5 +270,5 @@ if (PYBIND)
         # above to use ${PYTHON_SITE_PACKAGES} instead of ${Pyhon_SITEARCH}
         install(FILES build-pybind/$<TARGET_FILE_NAME:CyRSoXS> DESTINATION ${Python_SITEARCH})
 else ()
-        install(FILES build/CyRSoXS DESTINATION bin)
+        install(FILES build/CyRSoXS DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,10 @@ endif ()
 
 if (PYBIND)
         install(FILES build-pybind/$<TARGET_FILE_NAME:CyRSoXS> DESTINATION lib)
+        #execute_process(COMMAND ${Python_EXECUTABLE} -m pip install ${_pypkg})
+        #execute_process ( COMMAND python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+        # above to use ${PYTHON_SITE_PACKAGES} instead of ${Pyhon_SITEARCH}
+        install(FILES build-pybind/$<TARGET_FILE_NAME:CyRSoXS> DESTINATION ${Python_SITEARCH})
 else ()
         install(FILES build/CyRSoXS DESTINATION bin)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0048 NEW)
-project(Cy-RSoXS VERSION 9.1.5.0 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
+project(Cy-RSoXS VERSION 1.1.5.0 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
 
 
 option(DOUBLE_PRECISION "Use 64 bit indices for floating point" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 cmake_policy(SET CMP0048 NEW)
-project(Cy-RSoXS VERSION 1.1.5 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
+project(Cy-RSoXS VERSION 1.1.5.0 DESCRIPTION BetaVersion LANGUAGES CXX CUDA)
 
 
 option(DOUBLE_PRECISION "Use 64 bit indices for floating point" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ if (ENABLE_TEST)
 endif ()
 
 enable_language(CUDA)
+find_package(CUDAToolkit)
 # x peter commenting out to use new CUDA machinery in cmake >= 3.8 find_package(CUDA 9 REQUIRED)
 find_package(OpenMP REQUIRED)
 
@@ -173,7 +174,10 @@ if (PYBIND)
     target_include_directories(CyRSoXS PUBLIC ${Python_INCLUDE_DIRS} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} include)
     target_include_directories(CyRSoXS PRIVATE ${PROJECT_BINARY_DIR}/generated)
     target_link_libraries(CyRSoXS
-            ${Python_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas  "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" )
+            ${Python_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} CUDA::cublas CUDA::cufft CUDA::nppc CUDA::nppial CUDA::nppicc CUDA::nppidei CUDA::nppif CUDA::nppig CUDA::nppim CUDA::nppist CUDA::nppisu CUDA::nppitc CUDA::npps)
+    #${Python_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas -lcudart "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" )
+    
+
     if (EOC)
         target_include_directories(CyRSoXS PRIVATE ${OpenCV_INCLUDE_DIRS})
         target_link_libraries(CyRSoXS ${OpenCV_LIBS})
@@ -206,7 +210,7 @@ else ()
     target_include_directories(CyRSoXS PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} ${CONFIG++_INCLUDE_DIR} include)
     target_include_directories(CyRSoXS PRIVATE ${PROJECT_BINARY_DIR}/generated)
     target_link_libraries(CyRSoXS
-            ${Python_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas  "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" ${CONFIG++_LIBRARY})
+            ${Python_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} CUDA::cufft CUDA::cublas CUDA::nppc CUDA::nppial CUDA::nppicc CUDA::nppidei CUDA::nppif CUDA::nppig CUDA::nppim CUDA::nppist CUDA::nppisu CUDA::nppitc CUDA::npps ${CONFIG++_LIBRARY})
     if (EOC)
         target_include_directories(CyRSoXS PRIVATE ${OpenCV_INCLUDE_DIRS})
         target_link_libraries(CyRSoXS ${OpenCV_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if (PYBIND)
 
     cuda_add_library(CyRSoXS SHARED
             ${PYBIND_SRC} ${CyRSoXS_SRC} ${CyRSoXS_INC})
-    target_include_directories(CyRSoXS PUBLIC ${Python_INCLUDE_DIRS} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} include)
+    target_include_directories(CyRSoXS PUBLIC ${PYTHON_INCLUDE_DIRS} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} include)
     target_include_directories(CyRSoXS PRIVATE ${PROJECT_BINARY_DIR}/generated)
     target_link_libraries(CyRSoXS
             ${PYTHON_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas  "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ if (BUILD_DOCS)
 endif ()
 
 if (PYBIND)
-        install(FILES build-pybind/CyRSoXS.so DESTINATION lib)
+        install(FILES build-pybind/$<TARGET_FILE_NAME:CyRSoXS> DESTINATION lib)
 else ()
         install(FILES build/CyRSoXS DESTINATION bin)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ if (PYBIND)
     include_directories(
             ${PYTHON_INCLUDE_DIRS}
     )
+    find_package(pybind11 CONFIG)
 else ()
     find_package(Config++)
     if (NOT ${CONFIG++_FOUND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,8 @@ if (ENABLE_TEST)
     message("Test enabled")
 endif ()
 
-find_package(CUDA 9 REQUIRED)
+enable_language(CUDA)
+# x peter commenting out to use new CUDA machinery in cmake >= 3.8 find_package(CUDA 9 REQUIRED)
 find_package(OpenMP REQUIRED)
 
 if (OPENMP_FOUND)
@@ -113,7 +114,7 @@ find_package(HDF5 COMPONENTS CXX HL REQUIRED)
 
 
 
-
+set(CMAKE_CUDA_STANDARD 14) # pab added
 set(CMAKE_CXX_STANDARD 14)
 set(CyRSoXS_SRC
         src/RotationMatrix.cpp
@@ -167,7 +168,7 @@ if (PYBIND)
             )
 
 
-    cuda_add_library(CyRSoXS SHARED
+    add_library(CyRSoXS SHARED
             ${PYBIND_SRC} ${CyRSoXS_SRC} ${CyRSoXS_INC})
     target_include_directories(CyRSoXS PUBLIC ${Python_INCLUDE_DIRS} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} include)
     target_include_directories(CyRSoXS PRIVATE ${PROJECT_BINARY_DIR}/generated)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,9 +95,9 @@ if (PYBIND)
         include_directories(include/pybind11)
     endif ()
     include_directories(
-            ${PYTHON_INCLUDE_DIRS}
+            ${Python_INCLUDE_DIRS}
     )
-    find_package(pybind11 CONFIG)
+    find_package(pybind11 CONFIG REQUIRED)
 else ()
     find_package(Config++)
     if (NOT ${CONFIG++_FOUND})
@@ -169,10 +169,10 @@ if (PYBIND)
 
     cuda_add_library(CyRSoXS SHARED
             ${PYBIND_SRC} ${CyRSoXS_SRC} ${CyRSoXS_INC})
-    target_include_directories(CyRSoXS PUBLIC ${PYTHON_INCLUDE_DIRS} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} include)
+    target_include_directories(CyRSoXS PUBLIC ${Python_INCLUDE_DIRS} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} include)
     target_include_directories(CyRSoXS PRIVATE ${PROJECT_BINARY_DIR}/generated)
     target_link_libraries(CyRSoXS
-            ${PYTHON_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas  "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" )
+            ${Python_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas  "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" )
     if (EOC)
         target_include_directories(CyRSoXS PRIVATE ${OpenCV_INCLUDE_DIRS})
         target_link_libraries(CyRSoXS ${OpenCV_LIBS})
@@ -183,6 +183,14 @@ if (PYBIND)
             PREFIX ""
             )
 
+    pybind11_extension(CyRSoXS)
+    if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+        # Strip unnecessary sections of the binary on Linux/macOS
+        pybind11_strip(CyRSoXS)
+    endif()
+
+    set_target_properties(CyRSoXS PROPERTIES CXX_VISIBILITY_PRESET "hidden"
+                                         CUDA_VISIBILITY_PRESET "hidden") 
 else ()
     set(EXE_SRC
             src/main.cpp
@@ -197,7 +205,7 @@ else ()
     target_include_directories(CyRSoXS PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} ${HDF5_INCLUDE_DIR} ${CONFIG++_INCLUDE_DIR} include)
     target_include_directories(CyRSoXS PRIVATE ${PROJECT_BINARY_DIR}/generated)
     target_link_libraries(CyRSoXS
-            ${PYTHON_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas  "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" ${CONFIG++_LIBRARY})
+            ${Python_LIBRARIES} ${HDF5_CXX_LIBRARIES} ${HDF5_HL_LIBRARIES} -lcufft -lcublas  "${CUDA_nppc_LIBRARY};${CUDA_nppial_LIBRARY};${CUDA_nppicc_LIBRARY};${CUDA_nppidei_LIBRARY};${CUDA_nppif_LIBRARY};${CUDA_nppig_LIBRARY};${CUDA_nppim_LIBRARY};${CUDA_nppist_LIBRARY};${CUDA_nppisu_LIBRARY};${CUDA_nppitc_LIBRARY};${CUDA_npps_LIBRARY}" ${CONFIG++_LIBRARY})
     if (EOC)
         target_include_directories(CyRSoXS PRIVATE ${OpenCV_INCLUDE_DIRS})
         target_link_libraries(CyRSoXS ${OpenCV_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ if (PYBIND)
     # find_package(PythonInterp 3.6 REQUIRED)
     # find_package(PythonLibs 3.6 REQUIRED)
     find_package(Python 3 COMPONENTS Interpreter Development REQUIRED)
+    
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --verbose")
 
     if (USE_SUBMODULE_PYBIND)
         set(PYBIND_LOCATION "include/pybind11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif ()
 if (PYBIND)
     # find_package(PythonInterp 3.6 REQUIRED)
     # find_package(PythonLibs 3.6 REQUIRED)
-    find_package(Python COMPONENTS Interpreter Development REQUIRED)
+    find_package(Python 3 COMPONENTS Interpreter Development REQUIRED)
 
     if (USE_SUBMODULE_PYBIND)
         set(PYBIND_LOCATION "include/pybind11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,14 +91,14 @@ if (PYBIND)
     
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --verbose")
 
-    if (USE_SUBMODULE_PYBIND)
-        set(PYBIND_LOCATION "include/pybind11")
+        if (USE_SUBMODULE_PYBIND)
+        set(PYBIND_LOCATION external/pybind11)
         add_subdirectory(${PYBIND_LOCATION})
-        include_directories(include/pybind11)
+        include_directories(external/pybind11/include)
+    else ()
+        find_package(pybind11 CONFIG REQUIRED)
     endif ()
-    include_directories(
-            ${Python_INCLUDE_DIRS}
-    )
+    include_directories(${Python_INCLUDE_DIRS})
     find_package(pybind11 CONFIG REQUIRED)
 else ()
     find_package(Config++)

--- a/environment-build.yml
+++ b/environment-build.yml
@@ -3,12 +3,15 @@ name: cyrsoxs-build
 channels:
   - conda-forge
   - defaults
+  - nvidia
 dependencies:
   - cxx-compiler
   - pybind11
-  - cmake
+  - cmake>3.8
   - make
   - hdf5
   - libconfig
   - cudatoolkit
   - openmp
+  - cuda
+  - cuda-nvcc


### PR DESCRIPTION
The long and short of this is that I had to rewrite large parts of CMakeLists to support the modern invocation of CUDA to allow building on conda-forge.  We now have a hard lower version bound of cmake >= 3.8, which shouldn't be the end of the world, and we can build on c-f and produce conda packages.