### PR TITLE
Update documentation for hosting on readthedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__
 *.asv
 octave-workspace
 *.pickle
+docs/sphinx/_build
+docs/html
+docs/latex

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         = 1.1.5.0
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "GPU Accelerated RSoXS simulator"
+PROJECT_BRIEF          = "GPU Accelerated RSoXS Simulator"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -441,7 +441,7 @@ EXTRACT_ALL            = YES
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.
@@ -1068,7 +1068,7 @@ USE_HTAGS              = NO
 # See also: Section \class.
 # The default value is: YES.
 
-VERBATIM_HEADERS       = YES
+VERBATIM_HEADERS       = NO
 
 # If the CLANG_ASSISTED_PARSING tag is set to YES then doxygen will use the
 # clang parser (see: http://clang.llvm.org/) for more accurate parsing at the

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1068,7 +1068,7 @@ USE_HTAGS              = NO
 # See also: Section \class.
 # The default value is: YES.
 
-VERBATIM_HEADERS       = NO
+VERBATIM_HEADERS       = YES
 
 # If the CLANG_ASSISTED_PARSING tag is set to YES then doxygen will use the
 # clang parser (see: http://clang.llvm.org/) for more accurate parsing at the

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,4 +1,27 @@
-# GPU enabled RSoXS simulation (1.1.5.0)
+# CyRSoXS Installation Instructions (1.1.5.0)
+
+## Conda
+
+CyRSoXS is available as a pre-built binary on the `conda-forge` channel. To install:
+```bash
+conda install cyrsoxs -c conda-forge
+```
+
+## Building from source
+
+To build CyRSoXS from source, the following dependencies need to be installed:
+
+* A C++ compiler with C++14 support is required.
+* gcc >= 7 (CUDA specific versions might have GCC requirements )
+* Cuda Toolkit (>=9)
+* HDF5
+* OpenMP
+
+#### Additional dependencies for building with Pybind
+* Python >= 3.6
+
+#### Additional dependencies for building without Pybind
+* libconfig
 
 ## Compiling libconfig
 

--- a/docs/sphinx/Makefile
+++ b/docs/sphinx/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,0 +1,34 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+
+import subprocess, os
+
+
+subprocess.call('cd .. ; doxygen', shell=True)
+
+project = 'CyRSoXS'
+copyright = '2019-2022 Iowa State University'
+author = 'Kumar Saurabh, Adarsh Krishnamurthy, Baskar Ganapathysubramanian, Eliot Gann, Dean M. Delongchamp, Peter J. Dudenas, Tyler B. Martin, Peter Beaucage'
+release = '1.1.5.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+highlight_language = 'c++'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+html_extra_path = ['../html']

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,0 +1,18 @@
+.. CyRSoXS documentation master file, created by
+   sphinx-quickstart on Thu Oct 20 14:28:05 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to CyRSoXS's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/sphinx/make.bat
+++ b/docs/sphinx/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,21 +22,29 @@
 //SOFTWARE.
 //////////////////////////////////////////////////////////////////////////////////
 
-/*! \mainpage Welcome to CyRSoXS.
+/*! \mainpage Welcome to CyRSoXS
  *
  * \section Introduction
- * This is the GPU accelerated version of current RSoXS. Currently,
- * the code is tested on NVIDIA V100 GPU. This code can run on multiple GPU on
- * a single node and operates on single - precision floating point (FP32) operation.
- * In the current version of the code, speedup of up to two orders of magnitude is observed
- * as compared to the community accepted Igor based <a href="https://onlinelibrary.wiley.com/iucr/doi/10.1107/S1600577515019074">RSoXS</a> simulator.
+ * CyRSoXS is a GPU-accelerated codebase that calculates resonant X-ray scattering 
+ * in the Born Approximation. It takes a voxel-based model and optical constants as 
+ * input, and returns simulated X-ray scattering patterns. These models can be derived 
+ * from real space measurements (AFM, TEM, 4DSTEM), or synthetically generated using 
+ * procedural morphology generators. Currently, the code can run on multiple GPUs on a 
+ * single node and it supports both single- and double-precision floating point operations.
+ * A speedup of up to two orders of magnitude is observed as compared to the previous 
+ * state-of-the-art Igor-based <a href="https://onlinelibrary.wiley.com/iucr/doi/10.1107/S1600577515019074">RSoXS simulator.</a>
  *
+ * This core C++/CUDA simulation engine is used in the NIST RSoXS Simulation Suite (NRSS), which 
+ * includes additional Python code for creating, simulating, and analyzing RSoXS. For more
+ * information on NRSS, please see the <a href="https://nrss.readthedocs.io">documentation.</a>
+ * For more information on what RSoXS is and how you can possible apply it in your own 
+ * research, check out the <a href="https://www.nist.gov/programs-projects/resonant-soft-x-ray-scattering-rsoxs">NIST RSOXS project page.</a>
  *
  * \section Dependencies
  * The code has following dependencies:
  * <ul>
- *  <li> A GCC / intel compiler with c++ 14 standard
- *  <li> NVIDIA Graphics processing unit
+ *  <li> A GCC / Intel compiler with C++ 14 standard
+ *  <li> NVIDIA GPU
  *  <li> cuda-toolkit 9  and above
  *  <li> HDF5 library
  *  <li> Libconfig
@@ -45,15 +53,23 @@
  *  </ul>
  *
  *
- * \section Limitation
+ * \section Limitations
  * The current version of the code assumes that the complete data fits in
  * GPU memory.
  *
  * \section Contributors
+ * This software was developed at Iowa State University in collaboration with NIST.
+ * The Iowa State team provided expertise in high performance computing, and the
+ * NIST team provided scientific expertise on the RSoXS technique.
+ *
+ * <b>Iowa State University</b>
  * <ul>
  * <li> Kumar Saurabh
  * <li> Adarsh Krishnamurthy
  * <li> Baskar Ganapathysubramanian
+ * </ul>
+ * <b>NIST</b>
+ * <ul>
  * <li> Eliot Gann
  * <li> Dean M. Delongchamp
  * <li> Peter J. Dudenas
@@ -62,11 +78,12 @@
  * </ul>
  *
  * \section Acknowledgement
- * We thank ONR MURI Center for Self-Assembled Organic Electronics for providing the
+ * We thank ONR MURI Center for Self-Assembled Organic Electronics for providing 
  * support for this work.
  *
- * \copyright Copyright 2019-2022 Iowa State University. All rights reserved.
- * This project is released under the MIT License.
+ * \copyright 
+ * Copyright 2019-2022 Iowa State University. All rights reserved.
+ * This project is released under the MIT and NIST Licenses.
  *
  */
 


### PR DESCRIPTION
A sphinx-build directory was created, and the doxygen command is called from the conf.py file. This lets us host the doxygen-generated documentation on Read the Docs, and automatically update it with new commits.