### PR TITLE
Minor tweaks to enable custom module names in Pybind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if (PYBIND)
     else ()
         add_definitions(-DMAX_NUM_MATERIAL=32)
     endif()
+    configure_file(src/pymain.cpp src/pymain-tmp.cpp)
     set(PYBIND_INC
             include/PyClass/RefractiveIndex.h
             include/PyClass/VoxelData.h
@@ -170,7 +171,7 @@ if (PYBIND)
             include/PyClass/Polarization.h
             )
     set(PYBIND_SRC
-            src/pymain.cpp
+            src/pymain-tmp.cpp
             )
 
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -136,6 +136,7 @@ This will generate a `CyRSoXS.so` Shared Library file, which can be imported int
     -DPROFILING=Yes         # Enables profiling of the code
     -DBUILD_DOCS=Yes        # To build documentation
     -DCMAKE_CXX_COMPILER=icpc -DCMAKE_C_COMPILER=icc # Compiling with the Intel compiler (does not work with Pybind)
+    -DOUTPUT_BASE_NAME=CyRSoXS # Changes the name of the built output binary or Python module (if using Pybind)
 ```
 
 ## Making CyRSoXS

--- a/src/pymain.cpp
+++ b/src/pymain.cpp
@@ -125,7 +125,7 @@ void cleanup(RefractiveIndexData &energyData, VoxelData &voxelData, ScatteringPa
 
 }
 
-PYBIND11_MODULE(CyRSoXS, module) {
+PYBIND11_MODULE(@OUTPUT_BASE_NAME@, module) {
   module.doc() = "pybind11  plugin for CyRSoXS";
 
   py::print("CyRSoXS");


### PR DESCRIPTION
The previous PR (released as 1.1.5.1) had a bug where the binaries built fine with custom names, but the Pybind modules could not be imported.  This uses cmake's configure_file feature to template the user-defined custom module name into the pybind module itself.

I was on the fence about implementing this but it will also allow easier compilation of binaries that have different versions defined, simply by compiling with -DOUTPUT_BASE_NAME=CyRSoXS1151 or whatever.