### PR TITLE
Fixes for cuda 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ else ()
         target_link_libraries(${OUTPUT_BASE_NAME} ${OpenCV_LIBS})
     endif ()
 endif ()
-set_property(TARGET ${OUTPUT_BASE_NAME} PROPERTY CUDA_ARCHITECTURES  52 53 60 61 62 70 72)
+set_property(TARGET ${OUTPUT_BASE_NAME} PROPERTY CUDA_ARCHITECTURES  native)
 
 if (ENABLE_TEST)
     if (PYBIND)

--- a/include/cudaHeaders.h
+++ b/include/cudaHeaders.h
@@ -95,12 +95,12 @@ __host__ INLINE inline void cudaZeroEntries(T * d_data, const GI & size){
 #ifdef DOUBLE_PRECISION
 #define cublasScale cublasDscal
 #define cublasAXPY cublasDaxpy
-#define warpAffine nppiWarpAffine_64f_C1R
+#define warpAffine nppiWarpAffine_64f_C1R_Ctx
 #define cufftC2C cufftExecZ2Z
 #else
 #define cublasScale cublasSscal
 #define cublasAXPY cublasSaxpy
-#define warpAffine nppiWarpAffine_32f_C1R
+#define warpAffine nppiWarpAffine_32f_C1R_Ctx
 #define cufftC2C cufftExecC2C
 #endif
 

--- a/src/cudaMain.cu
+++ b/src/cudaMain.cu
@@ -445,6 +445,9 @@ int cudaMain(const UINT *voxel,
     } else {
       std::cout << "[INFO] [GPU = " << dprop.name << "] : " << energyStart << "eV -> " << energyEnd << "eV\n";
     }
+    NppStreamContext nppCtx;
+    nppCtx.hStream = 0; // NULL stream
+    
 
 
 #ifdef PROFILING
@@ -798,7 +801,8 @@ int cudaMain(const UINT *voxel,
                                         voxel[1] * sizeof(Real),
                                         rect,
                                         coeffs,
-                                        NPPI_INTER_LINEAR);
+                                        NPPI_INTER_LINEAR,
+                                        nppCtx);
 
           if (status < 0) {
             std::cout << "Image rotation failed with error = " << status << "\n";
@@ -882,7 +886,8 @@ int cudaMain(const UINT *voxel,
                                       voxel[1] * sizeof(Real),
                                       rect,
                                       coeffs,
-                                      NPPI_INTER_LINEAR);
+                                      NPPI_INTER_LINEAR,
+                                      nppCtx);
 
         if (status < 0) {
           std::cout << "Image rotation failed with error = " << status << "\n";
@@ -1090,6 +1095,9 @@ int cudaMainStreams(const UINT *voxel,
     rect.width = voxel[1];
     rect.x = 0;
     rect.y = 0;
+
+    NppStreamContext nppCtx;
+    nppCtx.hStream = 0; // NULL stream
 
 
     const UINT ompThreadID = omp_get_thread_num();
@@ -1426,7 +1434,8 @@ int cudaMainStreams(const UINT *voxel,
                                         voxel[1] * sizeof(Real),
                                         rect,
                                         coeffs,
-                                        NPPI_INTER_LINEAR);
+                                        NPPI_INTER_LINEAR,
+                                        nppCtx);
 
           if (status < 0) {
             std::cout << "Image rotation failed with error = " << status << "\n";
@@ -1508,7 +1517,8 @@ int cudaMainStreams(const UINT *voxel,
                                       voxel[1] * sizeof(Real),
                                       rect,
                                       coeffs,
-                                      NPPI_INTER_LINEAR);
+                                      NPPI_INTER_LINEAR,
+                                      nppCtx);
 
         if (status < 0) {
           std::cout << "Image rotation failed with error = " << status << "\n";


### PR DESCRIPTION
Trying to solve a couple of issue with cuda/13.

1. Replaceing nppiWarpAffine_64f_C1R/ nppiWarpAffine_32f_C1R with nppiWarpAffine_64f_C1R_Ctx/nppiWarpAffine_32f_C1R_Ctx. This is backward compatible with previous cuda version too.
2. Simplifying CmakeList architectures. Compiling the code for the native hardware that is present.