### PR TITLE
Fix/2d dc replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The developer version of the CyRSoXS code is available at <https://bitbucket.org
 
 ## [Visualization](docs/Visualization.md)
 
+## [Known Issues](docs/KNOWN_ISSUES.md)
+
 ## Documentation
 
 CyRSoXS documentation is available at <https://cyrsoxs.readthedocs.io>, and instructions to build the documentation are in the [Installation Instructions](docs/INSTALL.md).

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,29 @@
+# Known Issues
+
+No active issues are currently documented here.
+
+## Recently Resolved
+
+### 2D DC-component replacement for single-slice morphologies
+
+The `Nz == 1` DC-component replacement bug in `replaceDCComponentWithAverage(...)`
+has been fixed.
+
+The current behavior is:
+
+1. `Nz == 1` uses a 4-neighbor in-plane average.
+2. `Nz > 1` retains the existing 3D six-neighbor behavior.
+3. The DC voxel is no longer allowed to alias itself through the wrapped z-neighbor path.
+4. The out-of-bounds `z=+1` read for single-slice inputs is eliminated.
+
+The nearby polarization-kernel bounds checks were also tightened from
+`threadID > numVoxels` to `threadID >= numVoxels`.
+
+Validation used the NRSS pytest physics suite:
+
+1. `tests/validation/test_2d_disk_contrast_scaling.py`
+2. `tests/validation/test_analytical_2d_disk_form_factor.py`
+3. `tests/validation/test_analytical_sphere_form_factor.py`
+4. `tests/validation/test_sphere_contrast_scaling.py`
+
+Result: 6 tests passed against the local pybind build.

--- a/include/cudaHeaders.h
+++ b/include/cudaHeaders.h
@@ -95,12 +95,10 @@ __host__ INLINE inline void cudaZeroEntries(T * d_data, const GI & size){
 #ifdef DOUBLE_PRECISION
 #define cublasScale cublasDscal
 #define cublasAXPY cublasDaxpy
-#define warpAffine nppiWarpAffine_64f_C1R
 #define cufftC2C cufftExecZ2Z
 #else
 #define cublasScale cublasSscal
 #define cublasAXPY cublasSaxpy
-#define warpAffine nppiWarpAffine_32f_C1R
 #define cufftC2C cufftExecC2C
 #endif
 

--- a/include/uniaxial.h
+++ b/include/uniaxial.h
@@ -1050,7 +1050,7 @@ __host__ void rotateImage(Real *projection, const uint3 voxel, const Real rotAng
   cv::Point2f pc(image.cols/2., image.rows/2.);
   cv::Mat r = cv::getRotationMatrix2D(pc, rotAngle, 1.0);
   cv::Mat rotatedImage;
-  warpAffine(image, rotatedImage, r, image.size());
+  cv::warpAffine(image, rotatedImage, r, image.size());
   if (rotatedImage.isContinuous()) {
     std::memcpy(projection,rotatedImage.data,rotatedImage.rows*rotatedImage.cols);
   }

--- a/include/uniaxial.h
+++ b/include/uniaxial.h
@@ -443,7 +443,7 @@ __global__ void computePolarizationVectorMorphologyLowMemory(const Real4 * __res
                                                              Complex *polarizationY, Complex *polarizationZ,
                                                              const Matrix rotationMatrix, const BigUINT numVoxels) {
   const BigUINT threadID = threadIdx.x + blockIdx.x * blockDim.x;
-  if(threadID > numVoxels){
+  if(threadID >= numVoxels){
     return;
   }
   Complex pX{0,0}, pY{0,0}, pZ{0,0};

--- a/src/cudaMain.cu
+++ b/src/cudaMain.cu
@@ -64,50 +64,53 @@ __global__ void replaceDCComponentWithAverage(Complex *polarization, const uint3
   if (threadIdx.x == 0 && blockIdx.x == 0) {
     // DC component is at index [0,0,0]
     const int dcIndex = 0;
-    
-    // Calculate average of 6 immediate face-adjacent neighbors in 3D
+
+    // Use an in-plane stencil for single-slice inputs and preserve the
+    // existing six-neighbor stencil for true 3D morphologies.
     Complex sum = {0.0f, 0.0f};
     int count = 0;
-    
+
     // Neighbor at (1,0,0)
-    int idx = 1;
+    BigUINT idx = 1;
     sum.x += polarization[idx].x;
     sum.y += polarization[idx].y;
     count++;
-    
+
     // Neighbor at (0,1,0)
     idx = vx.x;
     sum.x += polarization[idx].x;
     sum.y += polarization[idx].y;
     count++;
-    
-    // Neighbor at (0,0,1)
-    idx = vx.x * vx.y;
-    sum.x += polarization[idx].x;
-    sum.y += polarization[idx].y;
-    count++;
-    
+
     // Neighbor at (vx.x-1,0,0) - wrap around due to periodicity
     idx = vx.x - 1;
     sum.x += polarization[idx].x;
     sum.y += polarization[idx].y;
     count++;
-    
+
     // Neighbor at (0,vx.y-1,0) - wrap around due to periodicity
-    idx = (vx.y - 1) * vx.x;
+    idx = static_cast<BigUINT>(vx.y - 1) * static_cast<BigUINT>(vx.x);
     sum.x += polarization[idx].x;
     sum.y += polarization[idx].y;
     count++;
-    
-    // Neighbor at (0,0,vx.z-1) - wrap around due to periodicity
-    idx = (vx.z - 1) * vx.x * vx.y;
-    sum.x += polarization[idx].x;
-    sum.y += polarization[idx].y;
-    count++;
-    
+
+    if (vx.z > 1) {
+      // Neighbor at (0,0,1)
+      idx = static_cast<BigUINT>(vx.x) * static_cast<BigUINT>(vx.y);
+      sum.x += polarization[idx].x;
+      sum.y += polarization[idx].y;
+      count++;
+
+      // Neighbor at (0,0,vx.z-1) - wrap around due to periodicity
+      idx = static_cast<BigUINT>(vx.z - 1) * static_cast<BigUINT>(vx.x) * static_cast<BigUINT>(vx.y);
+      sum.x += polarization[idx].x;
+      sum.y += polarization[idx].y;
+      count++;
+    }
+
     // Replace DC component with average
-    polarization[dcIndex].x = sum.x / count;
-    polarization[dcIndex].y = sum.y / count;
+    polarization[dcIndex].x = sum.x / static_cast<Real>(count);
+    polarization[dcIndex].y = sum.y / static_cast<Real>(count);
   }
 }
 
@@ -192,7 +195,7 @@ __global__ void computePolarization(const Material * d_materialConstants,
                                     const BigUINT numVoxels, const int DEVICE_NUM_MATERIAL
 ) {
   BigUINT threadID = threadIdx.x + blockIdx.x * blockDim.x;
-  if(threadID > numVoxels){
+  if(threadID >= numVoxels){
     return;
   }
 #ifndef BIAXIAL

--- a/src/cudaMain.cu
+++ b/src/cudaMain.cu
@@ -59,6 +59,67 @@ __host__ int performFFTShift(Complex *polarization, const UINT &blockSize, const
   return EXIT_SUCCESS;
 }
 
+// CUDA 13 removes nppGetStreamContext(), so populate the context explicitly.
+__host__ INLINE inline NppStreamContext getCurrentNppStreamContext() {
+  NppStreamContext nppCtx{};
+  const cudaStream_t stream = nppGetStream();
+
+  CUDA_CHECK_RETURN(cudaGetDevice(&nppCtx.nCudaDeviceId));
+
+  cudaDeviceProp deviceProps;
+  CUDA_CHECK_RETURN(cudaGetDeviceProperties(&deviceProps, nppCtx.nCudaDeviceId));
+
+  CUDA_CHECK_RETURN(cudaDeviceGetAttribute(&nppCtx.nCudaDevAttrComputeCapabilityMajor,
+                                           cudaDevAttrComputeCapabilityMajor,
+                                           nppCtx.nCudaDeviceId));
+  CUDA_CHECK_RETURN(cudaDeviceGetAttribute(&nppCtx.nCudaDevAttrComputeCapabilityMinor,
+                                           cudaDevAttrComputeCapabilityMinor,
+                                           nppCtx.nCudaDeviceId));
+
+  nppCtx.hStream = stream;
+  nppCtx.nMultiProcessorCount = deviceProps.multiProcessorCount;
+  nppCtx.nMaxThreadsPerMultiProcessor = deviceProps.maxThreadsPerMultiProcessor;
+  nppCtx.nMaxThreadsPerBlock = deviceProps.maxThreadsPerBlock;
+  nppCtx.nSharedMemPerBlock = deviceProps.sharedMemPerBlock;
+  nppCtx.nStreamFlags = cudaStreamDefault;
+  if (stream != 0) {
+    CUDA_CHECK_RETURN(cudaStreamGetFlags(stream, &nppCtx.nStreamFlags));
+  }
+  return nppCtx;
+}
+
+#ifdef DOUBLE_PRECISION
+__host__ INLINE inline NppStatus nppWarpAffineCtx(const Real *src,
+                                                  const NppiSize &srcSize,
+                                                  const int srcStep,
+                                                  const NppiRect &srcRoi,
+                                                  Real *dst,
+                                                  const int dstStep,
+                                                  const NppiRect &dstRoi,
+                                                  const double coeffs[2][3],
+                                                  const int interpolation,
+                                                  const NppStreamContext &nppCtx) {
+  return nppiWarpAffine_64f_C1R_Ctx(src, srcSize, srcStep, srcRoi,
+                                    dst, dstStep, dstRoi,
+                                    coeffs, interpolation, nppCtx);
+}
+#else
+__host__ INLINE inline NppStatus nppWarpAffineCtx(const Real *src,
+                                                  const NppiSize &srcSize,
+                                                  const int srcStep,
+                                                  const NppiRect &srcRoi,
+                                                  Real *dst,
+                                                  const int dstStep,
+                                                  const NppiRect &dstRoi,
+                                                  const double coeffs[2][3],
+                                                  const int interpolation,
+                                                  const NppStreamContext &nppCtx) {
+  return nppiWarpAffine_32f_C1R_Ctx(src, srcSize, srcStep, srcRoi,
+                                    dst, dstStep, dstRoi,
+                                    coeffs, interpolation, nppCtx);
+}
+#endif
+
 __global__ void replaceDCComponentWithAverage(Complex *polarization, const uint3 vx) {
   // Only execute this function with a single thread to avoid race conditions
   if (threadIdx.x == 0 && blockIdx.x == 0) {
@@ -395,6 +456,7 @@ int cudaMain(const UINT *voxel,
     cudaSetDevice(omp_get_thread_num());
     cudaDeviceProp dprop;
     cudaGetDeviceProperties(&dprop, omp_get_thread_num());
+    const NppStreamContext nppCtx = getCurrentNppStreamContext();
 
 #ifdef PROFILING
     if(warmup() == EXIT_SUCCESS){
@@ -793,15 +855,16 @@ int cudaMain(const UINT *voxel,
           };
 
 
-          NppStatus status = warpAffine(d_projection,
-                                        sizeImage,
-                                        voxel[1] * sizeof(Real),
-                                        rect,
-                                        d_rotProjection,
-                                        voxel[1] * sizeof(Real),
-                                        rect,
-                                        coeffs,
-                                        NPPI_INTER_LINEAR);
+          NppStatus status = nppWarpAffineCtx(d_projection,
+                                              sizeImage,
+                                              static_cast<int>(voxel[1] * sizeof(Real)),
+                                              rect,
+                                              d_rotProjection,
+                                              static_cast<int>(voxel[1] * sizeof(Real)),
+                                              rect,
+                                              coeffs,
+                                              NPPI_INTER_LINEAR,
+                                              nppCtx);
 
           if (status < 0) {
             std::cout << "Image rotation failed with error = " << status << "\n";
@@ -877,15 +940,16 @@ int cudaMain(const UINT *voxel,
         computeWarpAffineMatrix(srcPoints, destPoints, coeffs);
         Real _factor = idata.rotMask ? 0 : NAN;
         stat = cublasScale(handle, numVoxel2D, &_factor, d_projectionAverage, 1);
-        NppStatus status = warpAffine(d_projection,
-                                      sizeImage,
-                                      voxel[1] * sizeof(Real),
-                                      rect,
-                                      d_projectionAverage,
-                                      voxel[1] * sizeof(Real),
-                                      rect,
-                                      coeffs,
-                                      NPPI_INTER_LINEAR);
+        NppStatus status = nppWarpAffineCtx(d_projection,
+                                            sizeImage,
+                                            static_cast<int>(voxel[1] * sizeof(Real)),
+                                            rect,
+                                            d_projectionAverage,
+                                            static_cast<int>(voxel[1] * sizeof(Real)),
+                                            rect,
+                                            coeffs,
+                                            NPPI_INTER_LINEAR,
+                                            nppCtx);
 
         if (status < 0) {
           std::cout << "Image rotation failed with error = " << status << "\n";
@@ -1057,6 +1121,7 @@ int cudaMainStreams(const UINT *voxel,
     cudaSetDevice(omp_get_thread_num());
     cudaDeviceProp dprop;
     cudaGetDeviceProperties(&dprop, omp_get_thread_num());
+    const NppStreamContext nppCtx = getCurrentNppStreamContext();
 
 #ifdef PROFILING
     if(warmup() == EXIT_SUCCESS){
@@ -1421,15 +1486,16 @@ int cudaMainStreams(const UINT *voxel,
           };
 
 
-          NppStatus status = warpAffine(d_projection,
-                                        sizeImage,
-                                        voxel[1] * sizeof(Real),
-                                        rect,
-                                        d_rotProjection,
-                                        voxel[1] * sizeof(Real),
-                                        rect,
-                                        coeffs,
-                                        NPPI_INTER_LINEAR);
+          NppStatus status = nppWarpAffineCtx(d_projection,
+                                              sizeImage,
+                                              static_cast<int>(voxel[1] * sizeof(Real)),
+                                              rect,
+                                              d_rotProjection,
+                                              static_cast<int>(voxel[1] * sizeof(Real)),
+                                              rect,
+                                              coeffs,
+                                              NPPI_INTER_LINEAR,
+                                              nppCtx);
 
           if (status < 0) {
             std::cout << "Image rotation failed with error = " << status << "\n";
@@ -1503,15 +1569,16 @@ int cudaMainStreams(const UINT *voxel,
         computeWarpAffineMatrix(srcPoints, destPoints, coeffs);
         Real _factor = idata.rotMask ? 0 : NAN;
         stat = cublasScale(handle, numVoxel2D, &_factor, d_projectionAverage, 1);
-        NppStatus status = warpAffine(d_projection,
-                                      sizeImage,
-                                      voxel[1] * sizeof(Real),
-                                      rect,
-                                      d_projectionAverage,
-                                      voxel[1] * sizeof(Real),
-                                      rect,
-                                      coeffs,
-                                      NPPI_INTER_LINEAR);
+        NppStatus status = nppWarpAffineCtx(d_projection,
+                                            sizeImage,
+                                            static_cast<int>(voxel[1] * sizeof(Real)),
+                                            rect,
+                                            d_projectionAverage,
+                                            static_cast<int>(voxel[1] * sizeof(Real)),
+                                            rect,
+                                            coeffs,
+                                            NPPI_INTER_LINEAR,
+                                            nppCtx);
 
         if (status < 0) {
           std::cout << "Image rotation failed with error = " << status << "\n";


### PR DESCRIPTION
Two major commits, one to fix a bug with 2D morphologies that I introduced when I introduced the DC component interpolation code (they're now special-cased), and another more major set to address the changes in CUDA 13. @KumarSaurabh1992 this attempts to future-proof the implementation a bit more than your open pull request in the direction NVidia seems to be going, but I borrowed from your implementation.